### PR TITLE
Add dev watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Web application that composes and publishes visually rich, interactive travel it
 ## Milestone 1
 Initial static server with simple web page.
 
+## Development
+Run `npm run dev` during development to start the server with automatic restarts when files in `public/` or `server.js` change.
+
 ## Contribution Guidelines
 1. Fork → branch → pull request.
 2. Lint + unit tests mandatory.

--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const { spawn } = require('child_process');
+const path = require('path');
+
+let serverProcess;
+let restartTimer;
+
+function start() {
+  serverProcess = spawn('node', ['server.js'], { stdio: 'inherit' });
+}
+
+function restart() {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+  start();
+}
+
+function scheduleRestart() {
+  if (restartTimer) return;
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    console.log('Restarting server...');
+    restart();
+  }, 100);
+}
+
+start();
+
+const watchOptions = { recursive: true };
+
+fs.watch(path.join(__dirname, 'public'), watchOptions, scheduleRestart);
+fs.watch(path.join(__dirname, 'server.js'), scheduleRestart);
+
+process.on('SIGINT', () => {
+  if (serverProcess) serverProcess.kill();
+  process.exit();
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "lint": "node lint.js",
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "dev": "node dev.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `dev.js` to restart `server.js` on changes
- document the development watcher in README
- expose a `dev` npm script in package.json

## Testing
- `npm run lint`
- `npm test`
