### PR TITLE
Add simple itinerary API

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -4,23 +4,58 @@ const assert = require('assert');
 
 const server = child_process.spawn('node', ['server.js']);
 
-server.stdout.on('data', data => {
-  // Wait for server to start then run test
-  if (data.toString().includes('Server running')) {
-    http.get('http://localhost:3000', res => {
-      try {
-        assert.strictEqual(res.statusCode, 200);
-        console.log('Test passed');
-        server.kill();
-      } catch (err) {
-        console.error('Test failed', err);
-        server.kill();
-        process.exitCode = 1;
-      }
-    }).on('error', err => {
-      console.error('Request error', err);
-      server.kill();
-      process.exitCode = 1;
+function waitForServer() {
+  return new Promise(resolve => {
+    server.stdout.on('data', data => {
+      if (data.toString().includes('Server running')) resolve();
     });
+  });
+}
+
+function request(options, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(options, res => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => resolve({ res, data }));
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+async function run() {
+  await waitForServer();
+  try {
+    let result = await request({ hostname: 'localhost', port: 3000, path: '/' });
+    assert.strictEqual(result.res.statusCode, 200);
+
+    result = await request({ hostname: 'localhost', port: 3000, path: '/api/itinerary' });
+    assert.strictEqual(result.res.statusCode, 200);
+    assert.deepStrictEqual(JSON.parse(result.data), []);
+
+    result = await request({
+      hostname: 'localhost',
+      port: 3000,
+      path: '/api/itinerary',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }, JSON.stringify({ name: 'test' }));
+    assert.strictEqual(result.res.statusCode, 201);
+
+    result = await request({ hostname: 'localhost', port: 3000, path: '/api/itinerary' });
+    const data = JSON.parse(result.data);
+    assert.strictEqual(data.length, 1);
+    assert.strictEqual(data[0].name, 'test');
+
+    console.log('All tests passed');
+  } catch (err) {
+    console.error('Test failed', err);
+    process.exitCode = 1;
+  } finally {
+    server.kill();
   }
-});
+}
+
+run();


### PR DESCRIPTION
## Summary
- implement an in-memory itinerary store in `server.js`
- route `/api/itinerary` GET and POST requests
- update tests for new API endpoints

## Testing
- `npm run lint`
- `npm test`
